### PR TITLE
feat: show number of listens in yim

### DIFF
--- a/alistral_cli/src/models/datastructures/tops/printer/mod.rs
+++ b/alistral_cli/src/models/datastructures/tops/printer/mod.rs
@@ -14,13 +14,19 @@ impl TopPrinter {
         let mut table_model = Table::new();
         table_model
             .load_preset(UTF8_FULL_CONDENSED)
-            .set_header(vec!["Rank", "Score", "Title"]);
+            .set_header(vec!["Rank", "Score", "Listens", "Title"]);
 
-        // Set the default alignment for the score column to right
-        let column = table_model
+        // Set the default alignment for the "score" column to right
+        let score_column = table_model
             .column_mut(1)
-            .expect("Our table has three columns");
-        column.set_cell_alignment(CellAlignment::Right);
+            .expect("Couldn't get a reference to the score column");
+        score_column.set_cell_alignment(CellAlignment::Right);
+
+        // Set the default alignment for the "listens" column to right
+        let listens_column = table_model
+            .column_mut(2)
+            .expect("Couldn't get a reference to the score column");
+        listens_column.set_cell_alignment(CellAlignment::Right);
 
         table_model
     }
@@ -33,6 +39,7 @@ impl TopPrinter {
                 table.add_row(vec![
                     row.rank_col(),
                     row.score_col(),
+                    row.listen_count_col(),
                     row.element_col().await,
                 ]);
             }

--- a/alistral_cli/src/models/datastructures/tops/printer/top_row.rs
+++ b/alistral_cli/src/models/datastructures/tops/printer/top_row.rs
@@ -10,6 +10,7 @@ pub struct TopRow {
     pub ranking: usize,
     pub previous_ranking: Option<usize>,
 
+    pub listen_count: usize,
     pub score: TopScore,
     pub previous_score: Option<TopScore>,
 
@@ -28,6 +29,10 @@ impl TopRow {
                 format!("≪ {previous_ranking:>3}").true_color_tup((100, 100, 100))
             ),
         }
+    }
+
+    pub fn listen_count_col(&self) -> String {
+        format!("{}", self.listen_count)
     }
 
     pub fn score_col(&self) -> String {

--- a/alistral_cli/src/tools/stats/year_in_music/components/top_with_cmp.rs
+++ b/alistral_cli/src/tools/stats/year_in_music/components/top_with_cmp.rs
@@ -5,6 +5,7 @@ use alistral_core::datastructures::entity_with_listens::label::collection::Label
 use alistral_core::datastructures::entity_with_listens::recording::collection::RecordingWithListensCollection;
 use alistral_core::datastructures::entity_with_listens::release_group::collection::ReleaseGroupWithReleasesCollection;
 use alistral_core::datastructures::entity_with_listens::traits::ListenCollWithTime as _;
+use alistral_core::datastructures::listen_collection::traits::ListenCollectionReadable;
 use duplicate::duplicate_item;
 use itertools::Itertools as _;
 use sequelles::datastructures::ranking::Ranking;
@@ -59,6 +60,7 @@ impl YimReport {
 
                 TopRow {
                     ranking: rank + 1,
+                    listen_count: rec.listen_count(),
                     score: TopScore::TimeDelta(rec.get_time_listened().unwrap_or_default()),
                     element: Box::new(rec.entity().clone()),
                     previous_ranking: prev.as_ref().map(|(rank, _)| rank + 1),

--- a/alistral_cli/src/tools/stats/year_in_music/mod.rs
+++ b/alistral_cli/src/tools/stats/year_in_music/mod.rs
@@ -1,7 +1,15 @@
 use core::cmp::Reverse;
 
+use crate::ALISTRAL_CLIENT;
+use crate::models::datastructures::tops::printer::TopPrinter;
+use crate::models::datastructures::tops::printer::top_row::TopRow;
+use crate::models::datastructures::tops::top_score::TopScore;
+use crate::tools::stats::year_in_music::stats::YimReportData;
+use crate::utils::cli::await_next;
+use crate::utils::user_inputs::UserInputParser;
 use alistral_core::datastructures::entity_with_listens::recording::RecordingWithListens;
 use alistral_core::datastructures::entity_with_listens::traits::ListenCollWithTime as _;
+use alistral_core::datastructures::listen_collection::traits::ListenCollectionReadable;
 use alistral_core::models::listen_statistics_data::ListenStatisticsData;
 use chrono::DateTime;
 use chrono::Datelike;
@@ -11,14 +19,6 @@ use chrono::Utc;
 use clap::Parser;
 use itertools::Itertools as _;
 use sequelles::datastructures::ranking::Ranking;
-
-use crate::ALISTRAL_CLIENT;
-use crate::models::datastructures::tops::printer::TopPrinter;
-use crate::models::datastructures::tops::printer::top_row::TopRow;
-use crate::models::datastructures::tops::top_score::TopScore;
-use crate::tools::stats::year_in_music::stats::YimReportData;
-use crate::utils::cli::await_next;
-use crate::utils::user_inputs::UserInputParser;
 
 pub mod artists;
 pub mod components;
@@ -149,6 +149,7 @@ impl YimReport {
             .into_iter()
             .map(|(rank, rec)| TopRow {
                 ranking: rank + 1,
+                listen_count: rec.listen_count(),
                 score: TopScore::TimeDelta(rec.get_time_listened().unwrap_or_default()),
                 element: Box::new(rec.recording().clone()),
                 previous_ranking: None,


### PR DESCRIPTION
This adds the total number of listens to the top recordings section in the year in music report.

Fixes #1009.

### Example
<img width="2244" height="1118" alt="image" src="https://github.com/user-attachments/assets/9cebb887-2c60-4fe8-81b2-ad82d4262397" />

(By the way, feel free to modify or amend any of my PRs)