### PR TITLE
feat: show duration of tracks/recordings in yim

### DIFF
--- a/alistral_cli/src/models/datastructures/tops/printer/top_row.rs
+++ b/alistral_cli/src/models/datastructures/tops/printer/top_row.rs
@@ -4,7 +4,7 @@ use tuillez::formatter::FormatWithAsyncDyn;
 use crate::datastructures::formaters::human_time::HumanTimePrinter;
 use crate::interface::comp_arrow::ComparisonArrow;
 use crate::models::datastructures::tops::printer::top_cell::TopCell;
-use crate::utils::constants::LISTENBRAINZ_FMT;
+use crate::utils::constants::{LISTENBRAINZ_FMT, YIM_FMT};
 
 pub struct TopRow {
     pub ranking: Option<TopCell<usize>>,
@@ -66,9 +66,13 @@ impl TopRow {
         }
     }
 
-    pub async fn element_col(&self) -> String {
+    pub async fn element_col(&self, with_duration: bool) -> String {
         self.element
-            .format_with_async(&LISTENBRAINZ_FMT)
+            .format_with_async(if with_duration {
+                &YIM_FMT
+            } else {
+                &LISTENBRAINZ_FMT
+            })
             .await
             .unwrap()
     }

--- a/alistral_cli/src/models/datastructures/tops/printer/top_table_printer.rs
+++ b/alistral_cli/src/models/datastructures/tops/printer/top_table_printer.rs
@@ -14,6 +14,9 @@ pub struct TopTablePrinter {
 
     #[builder(default = TopColumnSort::Desc)]
     sort_order: TopColumnSort,
+
+    #[builder(default = false)]
+    show_durations: bool,
 }
 
 impl TopTablePrinter {
@@ -29,7 +32,7 @@ impl TopTablePrinter {
         for col in &self.columns {
             match col {
                 TopColumnType::Rank => new_row.push(row.rank_col()),
-                TopColumnType::Title => new_row.push(row.element_col().await),
+                TopColumnType::Title => new_row.push(row.element_col(self.show_durations).await),
                 TopColumnType::ListenCount => new_row.push(row.listen_col(5, 5)),
                 TopColumnType::ListenDuration => new_row.push(row.score_col()),
             }

--- a/alistral_cli/src/tools/stats/year_in_music/components/top_with_cmp.rs
+++ b/alistral_cli/src/tools/stats/year_in_music/components/top_with_cmp.rs
@@ -89,6 +89,7 @@ impl YimReport {
             .columns(self.get_top_columns())
             .sorted_column(TopColumnType::ListenDuration)
             .sort_order(TopColumnSort::Desc)
+            .show_durations(true)
             .build();
 
         table.format_n_rows(rows, 20).await

--- a/alistral_cli/src/tools/stats/year_in_music/mod.rs
+++ b/alistral_cli/src/tools/stats/year_in_music/mod.rs
@@ -179,6 +179,7 @@ impl YimReport {
             .columns(self.get_top_columns())
             .sorted_column(TopColumnType::ListenDuration)
             .sort_order(TopColumnSort::Desc)
+            .show_durations(true)
             .build();
 
         table.format_n_rows(rows, 20).await

--- a/alistral_cli/src/utils/constants/mod.rs
+++ b/alistral_cli/src/utils/constants/mod.rs
@@ -14,6 +14,7 @@ pub mod paths;
 pub static MUSIBRAINZ_FMT: LazyLock<MusicbrainzFormater> = LazyLock::new(|| MusicbrainzFormater {
     artist_credits: true,
     listenbrainz_link: false,
+    duration: false,
     client: ALISTRAL_CLIENT.musicbrainz_db.clone(),
 });
 
@@ -21,8 +22,17 @@ pub static LISTENBRAINZ_FMT: LazyLock<MusicbrainzFormater> =
     LazyLock::new(|| MusicbrainzFormater {
         artist_credits: true,
         listenbrainz_link: true,
+        duration: false,
         client: ALISTRAL_CLIENT.musicbrainz_db.clone(),
     });
+
+#[cfg(feature = "stats")]
+pub static YIM_FMT: LazyLock<MusicbrainzFormater> = LazyLock::new(|| MusicbrainzFormater {
+    artist_credits: true,
+    listenbrainz_link: true,
+    duration: true,
+    client: ALISTRAL_CLIENT.musicbrainz_db.clone(),
+});
 
 #[cfg(all(feature = "youtube", feature = "interzic"))]
 pub static YT_SECRET_FILE: LazyLock<PathBuf> = LazyLock::new(|| {

--- a/musicbrainz_db_lite/src/models/musicbrainz/mod.rs
+++ b/musicbrainz_db_lite/src/models/musicbrainz/mod.rs
@@ -28,4 +28,7 @@ pub struct MusicbrainzFormater {
 
     /// Add the artist credits of the enitity as well.
     pub artist_credits: bool,
+
+    /// Show duration information where applicable
+    pub duration: bool,
 }

--- a/symphonize/src/utils/mod.rs
+++ b/symphonize/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub fn formater(client: &SymphonyzeClient) -> MusicbrainzFormater {
     MusicbrainzFormater {
         artist_credits: true,
         listenbrainz_link: false,
+        duration: false,
         client: client.mb_database.clone(),
     }
 }


### PR DESCRIPTION
This adds the duration of each top track/recording in the year in music report.

Fixes #1008.

### Example
<img width="1420" height="1122" alt="image" src="https://github.com/user-attachments/assets/7ff20876-bcc4-4000-88ac-7d63902c619b" />