### PR TITLE
feat: allow specifying MusicBrainz server by ip:port

### DIFF
--- a/alistral_cli/src/models/client/mod.rs
+++ b/alistral_cli/src/models/client/mod.rs
@@ -64,7 +64,7 @@ impl AlistralCliClient {
         let mut musicbrainz_rs = MusicBrainzClient::default();
         let url =
             url::Url::from_str(&config.musicbrainz_url).expect("Couldn't parse musicbrainz's url");
-        musicbrainz_rs.musicbrainz_domain = url.domain().unwrap().to_string();
+        musicbrainz_rs.musicbrainz_domain = url.authority().to_string();
         Arc::new(musicbrainz_rs)
     }
 


### PR DESCRIPTION
Requiring a domain when parsing the URL crashes if the configuration contains a port or an IP. Simply passing the raw authority as a "domain" fixes this issue.

Also see my upstream PR RustyNova016/musicbrainz_rs#233 which renames "domain" to "authority" to better encapsulate the concept.